### PR TITLE
Fix Makefile command indentation in scoreserver

### DIFF
--- a/scoreserver/makefile
+++ b/scoreserver/makefile
@@ -14,13 +14,13 @@ OBJ=$(SRC:.java=.class)
 all: $(OBJ) jar
 
 jar::
-        @echo Building jar file for Score Client
-        @jar -0cvf score_client.jar ScoreC*.class DataConnection*.class
+	@echo Building jar file for Score Client
+	@jar -0cvf score_client.jar ScoreC*.class DataConnection*.class
 
 .java.class:
-        @echo Compiling $<
-        @${JAVAC}       $<
+	@echo Compiling $<
+	@${JAVAC}       $<
 
 clean:
-        @rm -f $(OBJ) *.class *.jar
-        @echo Done
+	@rm -f $(OBJ) *.class *.jar
+	@echo Done


### PR DESCRIPTION
## Summary
- replace leading spaces with tabs in `scoreserver/makefile` command sections so `make` recognizes them

## Testing
- `make`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_68b4ba6ecde483218fdca5e9d0906f10