### PR TITLE
Fix Makefile indentation in maki directory

### DIFF
--- a/maki/makefile
+++ b/maki/makefile
@@ -14,13 +14,13 @@ JAR=maki.jar
 all: $(OBJ) $(JAR)
 
 $(JAR)::
-        @echo Building ${JAR} file
-        @jar -0cvf ${JAR} *.class
+	@echo Building ${JAR} file
+	@jar -0cvf ${JAR} *.class
 
 .java.class:
-        @echo Compiling $<
-        @${JAVAC}       $<
+	@echo Compiling $<
+	@${JAVAC}       $<
 
 clean:
-        @rm -f $(OBJ) *.class *.jar
-        @echo Done
+	@rm -f $(OBJ) *.class *.jar
+	@echo Done


### PR DESCRIPTION
## Summary
- Replace space-indented commands with tab-indented commands in maki/makefile to satisfy GNU Make requirements

## Testing
- `make clean`
- `make` *(fails: cannot find symbol ScoreClient)*

------
https://chatgpt.com/codex/tasks/task_e_68b4bd4ab6b48321a16148be31f4b870