### PR TITLE
Port Maki and ScoreServer for browser

### DIFF
--- a/maki/maki.html
+++ b/maki/maki.html
@@ -1,32 +1,36 @@
-<HTML>
-<SCRIPT LANGUAGE="JavaScript">
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Maki</title>
+    <script src="Maki.js"></script>
+    <script src="../scoreserver/ScoreServer.js"></script>
+    <script>
+        let game;
 
-function resetMaki()
-{
-	document.maki.reset();
-	return true;
-}
+        window.addEventListener('load', () => {
+            // Instantiate scoreboard service and the game once the page loads.
+            new ScoreServer();
+            const canvas = document.getElementById('maki');
+            game = new Maki(canvas);
+        });
 
-function undoMaki()
-{
-	document.maki.undo();
-	return true;
-}
+        function resetMaki() {
+            if (game) game.reset();
+        }
 
-</SCRIPT>
-<TITLE>Maki</TITLE>
-<BODY BGCOLOR=#FFFFFF>
-<CENTER>
-<APPLET NAME=maki CODE=Maki.class CODEBASE="." HEIGHT=500 WIDTH=500>
-</APPLET>
-<APPLET NAME=server CODE=ScoreServer.class CODEBASE="../scoreserver" WIDTH=1 HEIGHT=1>
-<PARAM NAME=game VALUE=MAKI>
-<PARAM NAME=server VALUE=hpwine40.uksr.hp.com>
-</APPLET>
-<FORM>
-<INPUT TYPE=BUTTON VALUE="New Game" onClick="resetMaki();">
-<INPUT TYPE=BUTTON VALUE="Undo" onClick="undoMaki();">
-</FORM>
-</CENTER>
-</BODY>
-</HTML>
+        function undoMaki() {
+            if (game) game.undo();
+        }
+    </script>
+</head>
+<body bgcolor="#FFFFFF">
+    <center>
+        <canvas id="maki" width="500" height="500"></canvas>
+        <form>
+            <input type="button" value="New Game" onclick="resetMaki();">
+            <input type="button" value="Undo" onclick="undoMaki();">
+        </form>
+    </center>
+</body>
+</html>
+

--- a/org/teavm/jso/JSBody.java
+++ b/org/teavm/jso/JSBody.java
@@ -1,0 +1,10 @@
+package org.teavm.jso;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+public @interface JSBody {
+    String script();
+    String[] params() default {};
+}

--- a/org/teavm/jso/JSExport.java
+++ b/org/teavm/jso/JSExport.java
@@ -1,0 +1,7 @@
+package org.teavm.jso;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR})
+public @interface JSExport {}

--- a/org/teavm/jso/browser/Window.java
+++ b/org/teavm/jso/browser/Window.java
@@ -1,0 +1,15 @@
+package org.teavm.jso.browser;
+
+import org.teavm.jso.dom.html.HTMLDocument;
+
+public class Window {
+    private static final Window INSTANCE = new Window();
+
+    public static Window current() {
+        return INSTANCE;
+    }
+
+    public HTMLDocument getDocument() {
+        return new HTMLDocument();
+    }
+}

--- a/org/teavm/jso/canvas/CanvasRenderingContext2D.java
+++ b/org/teavm/jso/canvas/CanvasRenderingContext2D.java
@@ -1,0 +1,9 @@
+package org.teavm.jso.canvas;
+
+public class CanvasRenderingContext2D {
+    public void setFillStyle(String style) {}
+    public void fillRect(double x, double y, double w, double h) {}
+    public void strokeRect(double x, double y, double w, double h) {}
+    public void clearRect(double x, double y, double w, double h) {}
+    public void fillText(String text, double x, double y) {}
+}

--- a/org/teavm/jso/dom/events/EventListener.java
+++ b/org/teavm/jso/dom/events/EventListener.java
@@ -1,0 +1,5 @@
+package org.teavm.jso.dom.events;
+
+public interface EventListener<T> {
+    void handleEvent(T evt);
+}

--- a/org/teavm/jso/dom/events/MouseEvent.java
+++ b/org/teavm/jso/dom/events/MouseEvent.java
@@ -1,0 +1,6 @@
+package org.teavm.jso.dom.events;
+
+public class MouseEvent {
+    public double getOffsetX() { return 0; }
+    public double getOffsetY() { return 0; }
+}

--- a/org/teavm/jso/dom/html/HTMLCanvasElement.java
+++ b/org/teavm/jso/dom/html/HTMLCanvasElement.java
@@ -1,0 +1,20 @@
+package org.teavm.jso.dom.html;
+
+import org.teavm.jso.canvas.CanvasRenderingContext2D;
+import org.teavm.jso.dom.events.EventListener;
+import org.teavm.jso.dom.events.MouseEvent;
+
+public class HTMLCanvasElement {
+    public CanvasRenderingContext2D getContext(String type) {
+        return new CanvasRenderingContext2D();
+    }
+
+    public void addEventListener(String event, EventListener<MouseEvent> listener) {
+        // no-op
+    }
+
+    public void setWidth(int w) {}
+    public void setHeight(int h) {}
+    public int getWidth() { return 0; }
+    public int getHeight() { return 0; }
+}

--- a/org/teavm/jso/dom/html/HTMLDocument.java
+++ b/org/teavm/jso/dom/html/HTMLDocument.java
@@ -1,0 +1,7 @@
+package org.teavm.jso.dom.html;
+
+public class HTMLDocument {
+    public HTMLCanvasElement getElementById(String id) {
+        return new HTMLCanvasElement();
+    }
+}

--- a/scoreserver/ScoreServer.java
+++ b/scoreserver/ScoreServer.java
@@ -1,229 +1,155 @@
-import java.io.BufferedReader;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.ServerSocket;
-import java.net.Socket;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
+import org.teavm.jso.JSBody;
+import org.teavm.jso.JSExport;
 
-public class ScoreServer
-{
-        ServerSocket serverSocket;
-        List<GameTable> games;
+/**
+ * Minimal in-browser scoreboard server.  The original implementation listened
+ * on a TCP port which is not possible inside a browser environment.  This
+ * version keeps the same command based protocol but exposes a single
+ * {@link #handle(String)} method that can be invoked from JavaScript.
+ */
+@JSExport
+public class ScoreServer {
+    List<GameTable> games;
 
-        static class Player
-	{
-		String playerName;
-		int playerScore;
-		
-		public Player(String name, int score)
-		{
-			playerName = name;
-			playerScore = score;
-		}
-	}
+    static class Player {
+        String playerName;
+        int playerScore;
 
-        static class GameTable
-	{
-		String name;
-                List<Player> playerScores;
+        public Player(String name, int score) {
+            playerName = name;
+            playerScore = score;
+        }
+    }
 
-                public GameTable(String pName)
-                {
-                        playerScores = new ArrayList<>();
-                        for(int i=0;i<10;i++)
-                        {
-                                Player p = new Player(pName + " " + (i+1), 0);
-                                playerScores.add(p);
-                        }
+    static class GameTable {
+        String name;
+        List<Player> playerScores;
 
-                        name = pName;
-                }
-
-                public boolean isHiScore(int score)
-                {
-                        Player p;
-
-                        p = playerScores.get(9);
-
-                        return(score > p.playerScore);
-                }
-
-                public void addScore(String name, int score)
-                {
-                        Player p = new Player(name, score);
-                        Player hiPlayer;
-                        int i;
-
-                        i = 0;
-                        while(i < 10)
-                        {
-                                hiPlayer = playerScores.get(i);
-                                if(p.playerScore > hiPlayer.playerScore)
-                                {
-                                        playerScores.add(i, p);
-                                        break;
-                                }
-                                i++;
-                        }
-                }
-
-                public String getScores()
-                {
-                        StringBuilder sb = new StringBuilder();
-                        int i;
-                        Player p;
-
-                        for(i=0;i<10;i++)
-                        {
-                                p = playerScores.get(i);
-                                if(i > 0)
-                                {
-                                        sb.append(";");
-                                }
-                                sb.append(p.playerName);
-                                sb.append("#");
-                                sb.append(p.playerScore);
-                        }
-                        return sb.toString();
-                }
+        public GameTable(String pName) {
+            playerScores = new ArrayList<>();
+            for (int i = 0; i < 10; i++) {
+                Player p = new Player(pName + " " + (i + 1), 0);
+                playerScores.add(p);
+            }
+            name = pName;
         }
 
-        private GameTable findGame(String game)
-        {
-                if(games.isEmpty()) return null;
-
-                for(int i = 0; i < games.size(); i++)
-                {
-                        GameTable g = games.get(i);
-                        if(g.name.equalsIgnoreCase(game)) return g;
-                }
-
-                return null;
+        public boolean isHiScore(int score) {
+            Player p = playerScores.get(9);
+            return (score > p.playerScore);
         }
 
-	private int isHi(String game, int score)
-	{
-		GameTable g = findGame(game);
-		if(g == null) return 0;
-		return (g.isHiScore(score) ? 1 : 0);
-	}
-
-	private String getTable(String game)
-	{
-		GameTable g = findGame(game);
-
-		if(g == null)
-		{
-                        g = new GameTable(game);
-                        games.add(g);
-		}
-
-		return g.getScores()+"\n";
-	}
-
-	private void addScore(String game, String pName, int pScore)
-	{
-		GameTable g;
-		
-		g = findGame(game);
-
-		if(g == null)
-		{
-                        g = new GameTable(game);
-                        games.add(g);
-		}
-
-		g.addScore(pName, pScore);
-	}
-
-	public ScoreServer()
-	{
-                games = new ArrayList<>();
-                String commandString = "";
-                String command = "";
-                String game = "";
-                String pName = "";
-                String score = "";
-                int pScore = 0;
-                String scoreList;
-                GameTable gt;
-
-                try
-                {
-                        serverSocket = new ServerSocket(9800);
-
-                        while(true)
-                        {
-                                try (Socket client = serverSocket.accept();
-                                     DataInputStream dataIn = new DataInputStream(client.getInputStream());
-                                     DataOutputStream dataOut = new DataOutputStream(client.getOutputStream());
-                                     BufferedReader textIn = new BufferedReader(new InputStreamReader(client.getInputStream())))
-                                {
-                                        System.out.println("Client connection made");
-
-                                        commandString = textIn.readLine();
-
-                                        StringTokenizer st = new StringTokenizer(commandString, "#");
-
-                                        int numTokens = st.countTokens();
-
-                                        command = st.nextToken();
-                                        game = st.nextToken();
-
-                                        if(numTokens >= 3)
-                                        {
-                                                score = st.nextToken();
-                                                pScore = Integer.parseInt(score);
-                                        }
-
-                                        if(numTokens >= 4)
-                                        {
-                                                pName = st.nextToken();
-                                        }
-
-                                        System.out.println("Command = " + command);
-                                        if(command.equalsIgnoreCase("get"))
-                                        {
-                                                scoreList = getTable(game);
-                                                dataOut.writeBytes(scoreList);
-                                        }
-
-                                        if(command.equalsIgnoreCase("clr"))
-                                        {
-                                                gt = findGame(game);
-                                                if(gt != null)
-                                                {
-                                                games.remove(gt);
-                                                gt = new GameTable(game);
-                                                games.add(gt);
-                                                }
-                                        }
-
-                                        if(command.equalsIgnoreCase("chk"))
-                                        {
-                                                dataOut.writeInt(isHi(game, pScore));
-                                        }
-
-                                        if(command.equalsIgnoreCase("add"))
-                                        {
-                                                addScore(game, pName, pScore);
-                                        }
-                                }
-                        }
+        public void addScore(String name, int score) {
+            Player p = new Player(name, score);
+            Player hiPlayer;
+            int i = 0;
+            while (i < 10) {
+                hiPlayer = playerScores.get(i);
+                if (p.playerScore > hiPlayer.playerScore) {
+                    playerScores.add(i, p);
+                    break;
                 }
-                catch(IOException exIO)
-                {
-                        System.out.println("Unable to create server socket");
-                        System.out.println(exIO.getMessage());
+                i++;
+            }
+        }
+
+        public String getScores() {
+            StringBuilder sb = new StringBuilder();
+            int i;
+            Player p;
+            for (i = 0; i < 10; i++) {
+                p = playerScores.get(i);
+                if (i > 0) {
+                    sb.append(";");
                 }
-		
-	}
-	public static void main(String argv[])
-	{
-		ScoreServer ss = new ScoreServer();
-	}
+                sb.append(p.playerName);
+                sb.append("#");
+                sb.append(p.playerScore);
+            }
+            return sb.toString();
+        }
+    }
+
+    private GameTable findGame(String game) {
+        if (games.isEmpty()) return null;
+        for (int i = 0; i < games.size(); i++) {
+            GameTable g = games.get(i);
+            if (g.name.equalsIgnoreCase(game)) return g;
+        }
+        return null;
+    }
+
+    private int isHi(String game, int score) {
+        GameTable g = findGame(game);
+        if (g == null) return 0;
+        return (g.isHiScore(score) ? 1 : 0);
+    }
+
+    private String getTable(String game) {
+        GameTable g = findGame(game);
+        if (g == null) {
+            g = new GameTable(game);
+            games.add(g);
+        }
+        return g.getScores();
+    }
+
+    private void addScore(String game, String pName, int pScore) {
+        GameTable g = findGame(game);
+        if (g == null) {
+            g = new GameTable(game);
+            games.add(g);
+        }
+        g.addScore(pName, pScore);
+    }
+
+    public ScoreServer() {
+        games = new ArrayList<>();
+        expose(this);
+    }
+
+    /**
+     * Handle a command of the form used by the original socket based protocol.
+     * For example: "get#MAKI" or "add#MAKI#100#Bob".
+     */
+    @JSExport
+    public String handle(String commandString) {
+        StringTokenizer st = new StringTokenizer(commandString, "#");
+        int numTokens = st.countTokens();
+        String command = st.nextToken();
+        String game = st.nextToken();
+        switch (command.toLowerCase()) {
+            case "get":
+                return getTable(game);
+            case "clr":
+                GameTable gt = findGame(game);
+                if (gt != null) {
+                    games.remove(gt);
+                    gt = new GameTable(game);
+                    games.add(gt);
+                }
+                return "";
+            case "chk":
+                if (numTokens >= 3) {
+                    int pScore = Integer.parseInt(st.nextToken());
+                    return Integer.toString(isHi(game, pScore));
+                }
+                return "0";
+            case "add":
+                if (numTokens >= 4) {
+                    int pScore = Integer.parseInt(st.nextToken());
+                    String pName = st.nextToken();
+                    addScore(game, pName, pScore);
+                }
+                return "";
+            default:
+                return "";
+        }
+    }
+
+    @JSBody(params = { "srv" }, script = "window.scoreServer = srv;")
+    private static native void expose(ScoreServer srv);
 }


### PR DESCRIPTION
## Summary
- Replace desktop AWT Maki implementation with a TeaVM-powered HTML5 canvas version and click handling.
- Rework ScoreServer into an in-browser scoreboard service exposed to JavaScript.
- Update `maki.html` to load generated scripts, instantiate the game and scoreboard, and hook up reset/undo buttons.
- Add stub TeaVM classes so the browser code compiles without external dependencies.

## Testing
- `xmllint --html -noout maki/maki.html` *(fails: command not found)*
- `javac maki/Maki.java scoreserver/ScoreServer.java`


------
https://chatgpt.com/codex/tasks/task_e_68b4c265dcbc8321931334691376522c