### PR TITLE
Fix Makefile tabs for jar rule

### DIFF
--- a/maki/makefile
+++ b/maki/makefile
@@ -18,8 +18,8 @@ JAR=maki.jar
 all: $(OBJ) $(JAR)
 
 $(JAR):: $(OBJ)
-        @echo Building ${JAR} file
-        @jar -0cvf ${JAR} $(OBJ)
+	@echo Building ${JAR} file
+	@jar -0cvf ${JAR} $(OBJ)
 
 .java.class:
 	@echo Compiling $<


### PR DESCRIPTION
## Summary
- fix jar rule commands in `maki/makefile` to use TABs instead of spaces so `make` runs correctly

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68b4cb11b6148321841c17de78760db7