### PR TITLE
Add desktop implementations of Maki and scoreboard server

### DIFF
--- a/maki-desktop/MakiDesktop.java
+++ b/maki-desktop/MakiDesktop.java
@@ -1,0 +1,233 @@
+import java.awt.Canvas;
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Standalone desktop version of the Maki game.
+ *
+ * <p>This implementation mirrors the logic of the browser based version
+ * but uses the Java AWT canvas for rendering so that the game can run
+ * as a normal desktop application.</p>
+ */
+public class MakiDesktop extends Canvas implements ActionListener {
+    private static final int MAX_X = 14, MAX_Y = 14;
+    private final int[][] board = new int[MAX_X][MAX_Y];
+    private final int[][] marker = new int[MAX_X][MAX_Y];
+    private final int[][] undoBoard = new int[MAX_X][MAX_Y];
+    private boolean gameOver = false;
+    private int score = 0, undoScore = 0;
+
+    public MakiDesktop() {
+        setSize((MAX_X + 4) * 25, (MAX_Y + 4) * 25);
+        addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                handleClick(e.getX(), e.getY());
+            }
+        });
+        initialiseBoard();
+    }
+
+    private void initialiseBoard() {
+        for (int x = 0; x < MAX_X; x++) {
+            for (int y = 0; y < MAX_Y; y++) {
+                marker[x][y] = 0;
+                board[x][y] = ThreadLocalRandom.current().nextInt(1, 6);
+            }
+        }
+        gameOver = false;
+        score = 0;
+        undoScore = 0;
+        repaint();
+    }
+
+    @Override
+    public void paint(Graphics g) {
+        for (int x = 0; x < MAX_X; x++) {
+            for (int y = 0; y < MAX_Y; y++) {
+                if (marker[x][y] > 0) {
+                    g.setColor(Color.black);
+                } else {
+                    switch (board[x][y]) {
+                        case 1: g.setColor(Color.red); break;
+                        case 2: g.setColor(Color.yellow); break;
+                        case 3: g.setColor(Color.blue); break;
+                        case 4: g.setColor(Color.white); break;
+                        case 5: g.setColor(Color.green); break;
+                        default: g.setColor(Color.white); break;
+                    }
+                }
+                if (board[x][y] > 0) {
+                    g.fillRect((x * 25) + 1, (y * 25) + 1, 23, 23);
+                    g.setColor(Color.black);
+                    g.drawRect((x * 25) + 1, (y * 25) + 1, 24, 24);
+                } else {
+                    g.clearRect((x * 25) + 1, (y * 25) + 1, 25, 25);
+                }
+            }
+        }
+        g.setColor(Color.black);
+        g.drawString("Score: " + score, (MAX_X + 1) * 25, 20);
+        if (gameOver) {
+            g.drawString("GAME OVER", 50, 50);
+        }
+    }
+
+    private void handleClick(int mx, int my) {
+        int boxX = mx / 25;
+        int boxY = my / 25;
+
+        if (gameOver) return;
+        if (boxX > MAX_X || boxY > MAX_Y) return;
+        if (boxX < 0 || boxY < 0) return;
+
+        if (board[boxX][boxY] == 0) {
+            clearBoxes(true);
+            repaint();
+            return;
+        }
+
+        if (marker[boxX][boxY] > 0) {
+            int boxesRemoved = countMarked();
+            score = score + (int) Math.pow((boxesRemoved - 2), 2);
+            clearBoxes(false);
+            packColumns();
+            shiftColumns();
+            gameOver = checkWin();
+            repaint();
+        } else {
+            saveUndo();
+            clearBoxes(true);
+            markBoxes(boxX, boxY, board[boxX][boxY]);
+            repaint();
+        }
+    }
+
+    private void clearBoxes(boolean reset) {
+        for (int x = 0; x < MAX_X; x++) {
+            for (int y = 0; y < MAX_Y; y++) {
+                if (marker[x][y] > 0) {
+                    if (!reset) board[x][y] = 0;
+                    marker[x][y] = 0;
+                }
+            }
+        }
+    }
+
+    private int countMarked() {
+        int marked = 0;
+        for (int x = 0; x < MAX_X; x++) {
+            for (int y = 0; y < MAX_Y; y++) {
+                if (marker[x][y] > 0) marked++;
+            }
+        }
+        return marked;
+    }
+
+    private void markBoxes(int x, int y, int colour) {
+        if (x < 0 || x >= MAX_X || y < 0 || y >= MAX_Y) return;
+        if (board[x][y] != colour || marker[x][y] > 0) return;
+        marker[x][y] = 1;
+        markBoxes(x + 1, y, colour);
+        markBoxes(x - 1, y, colour);
+        markBoxes(x, y + 1, colour);
+        markBoxes(x, y - 1, colour);
+    }
+
+    private void packColumns() {
+        for (int y = MAX_Y - 1; y >= 0; y--) {
+            for (int x = 0; x < MAX_X; x++) {
+                int j = y;
+                while (j < MAX_Y - 1) {
+                    if (board[x][j + 1] == 0) {
+                        board[x][j + 1] = board[x][j];
+                        board[x][j] = 0;
+                    }
+                    j++;
+                }
+            }
+        }
+    }
+
+    private void shiftColumns() {
+        for (int x = 1; x < MAX_X; x++) {
+            int j = x;
+            while (j > 0 && board[j - 1][MAX_Y - 1] == 0) {
+                for (int y = 0; y < MAX_Y; y++) {
+                    board[j - 1][y] = board[j][y];
+                    board[j][y] = 0;
+                }
+                j--;
+            }
+        }
+    }
+
+    private boolean checkWin() {
+        for (int y = MAX_Y - 1; y >= 0; y--) {
+            for (int x = 0; x < MAX_X; x++) {
+                if (board[x][y] > 0) {
+                    markBoxes(x, y, board[x][y]);
+                    int marked = countMarked();
+                    clearBoxes(true);
+                    if (marked > 1) return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private void saveUndo() {
+        for (int x = 0; x < MAX_X; x++) {
+            for (int y = 0; y < MAX_Y; y++) {
+                undoBoard[x][y] = board[x][y];
+            }
+        }
+        undoScore = score;
+    }
+
+    public void undo() {
+        for (int x = 0; x < MAX_X; x++) {
+            for (int y = 0; y < MAX_Y; y++) {
+                board[x][y] = undoBoard[x][y];
+            }
+        }
+        score = undoScore;
+        repaint();
+    }
+
+    public void reset() {
+        initialiseBoard();
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        String cmd = e.getActionCommand();
+        if ("New".equals(cmd)) {
+            reset();
+        } else if ("Undo".equals(cmd)) {
+            undo();
+        }
+    }
+
+    public static void main(String[] args) {
+        Frame frame = new Frame("Maki Desktop");
+        MakiDesktop game = new MakiDesktop();
+        frame.add(game);
+        frame.pack();
+        frame.setResizable(false);
+        frame.addWindowListener(new java.awt.event.WindowAdapter() {
+            @Override
+            public void windowClosing(java.awt.event.WindowEvent e) {
+                System.exit(0);
+            }
+        });
+        frame.setVisible(true);
+    }
+}
+

--- a/maki-desktop/README.md
+++ b/maki-desktop/README.md
@@ -1,0 +1,25 @@
+# Maki Desktop
+
+This directory contains a standalone desktop implementation of the Maki game
+and a simple scoreboard server.
+
+## Running the Game
+
+Compile and run:
+
+```bash
+javac MakiDesktop.java
+java MakiDesktop
+```
+
+## Running the Scoreboard Server
+
+The server listens on TCP port 9800 and uses the same text protocol as the
+original example:
+
+```bash
+javac ScoreServerDesktop.java
+java ScoreServerDesktop
+```
+
+The server keeps scores in memory for the duration of the process.

--- a/maki-desktop/ScoreServerDesktop.java
+++ b/maki-desktop/ScoreServerDesktop.java
@@ -1,0 +1,153 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+/**
+ * Simple desktop scoreboard server for the Maki game.
+ *
+ * <p>The server listens on TCP port 9800 and speaks the same text based
+ * protocol as the original implementation.  Each connection handles a single
+ * command and then closes.</p>
+ */
+public class ScoreServerDesktop {
+    private final List<GameTable> games = new ArrayList<>();
+
+    private static class Player {
+        String playerName;
+        int playerScore;
+        Player(String name, int score) {
+            playerName = name;
+            playerScore = score;
+        }
+    }
+
+    private static class GameTable {
+        String name;
+        List<Player> playerScores = new ArrayList<>();
+        GameTable(String pName) {
+            name = pName;
+            for (int i = 0; i < 10; i++) {
+                playerScores.add(new Player(pName + " " + (i + 1), 0));
+            }
+        }
+        boolean isHiScore(int score) {
+            Player p = playerScores.get(9);
+            return score > p.playerScore;
+        }
+        void addScore(String name, int score) {
+            Player p = new Player(name, score);
+            int i = 0;
+            while (i < playerScores.size() && p.playerScore <= playerScores.get(i).playerScore) {
+                i++;
+            }
+            playerScores.add(i, p);
+            if (playerScores.size() > 10) {
+                playerScores.remove(10);
+            }
+        }
+        String getScores() {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < 10; i++) {
+                Player p = playerScores.get(i);
+                if (i > 0) sb.append(';');
+                sb.append(p.playerName).append('#').append(p.playerScore);
+            }
+            return sb.toString();
+        }
+    }
+
+    private GameTable findGame(String game) {
+        for (GameTable g : games) {
+            if (g.name.equalsIgnoreCase(game)) return g;
+        }
+        return null;
+    }
+
+    private int isHi(String game, int score) {
+        GameTable g = findGame(game);
+        return g == null ? 0 : (g.isHiScore(score) ? 1 : 0);
+    }
+
+    private String getTable(String game) {
+        GameTable g = findGame(game);
+        if (g == null) {
+            g = new GameTable(game);
+            games.add(g);
+        }
+        return g.getScores();
+    }
+
+    private void addScore(String game, String name, int score) {
+        GameTable g = findGame(game);
+        if (g == null) {
+            g = new GameTable(game);
+            games.add(g);
+        }
+        g.addScore(name, score);
+    }
+
+    private String handle(String commandString) {
+        StringTokenizer st = new StringTokenizer(commandString, "#");
+        int numTokens = st.countTokens();
+        String command = st.nextToken();
+        String game = st.nextToken();
+        switch (command.toLowerCase()) {
+            case "get":
+                return getTable(game);
+            case "clr":
+                GameTable gt = findGame(game);
+                if (gt != null) {
+                    games.remove(gt);
+                    gt = new GameTable(game);
+                    games.add(gt);
+                }
+                return "";
+            case "chk":
+                if (numTokens >= 3) {
+                    int pScore = Integer.parseInt(st.nextToken());
+                    return Integer.toString(isHi(game, pScore));
+                }
+                return "0";
+            case "add":
+                if (numTokens >= 4) {
+                    int pScore = Integer.parseInt(st.nextToken());
+                    String pName = st.nextToken();
+                    addScore(game, pName, pScore);
+                }
+                return "";
+            default:
+                return "";
+        }
+    }
+
+    private void run() throws IOException {
+        try (ServerSocket server = new ServerSocket(9800)) {
+            while (true) {
+                try (Socket s = server.accept();
+                     BufferedReader in = new BufferedReader(new InputStreamReader(s.getInputStream()));
+                     PrintWriter out = new PrintWriter(s.getOutputStream(), true)) {
+                    String line = in.readLine();
+                    if (line != null) {
+                        String resp = handle(line);
+                        out.print(resp);
+                        if (!resp.isEmpty()) {
+                            out.print('\n');
+                        }
+                        out.flush();
+                    }
+                }
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        ScoreServerDesktop srv = new ScoreServerDesktop();
+        srv.run();
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce `maki-desktop` module with an AWT-based Maki game for desktop use
- Add a simple TCP scoreboard server for desktop environments
- Document build and run steps for the new desktop components

## Testing
- `javac MakiDesktop.java ScoreServerDesktop.java`

------
https://chatgpt.com/codex/tasks/task_e_68b4ed3444c483218e7cbb1095565478