### PR TITLE
Refactor battle project to eliminate deprecated Observer usage

### DIFF
--- a/battle/build.xml
+++ b/battle/build.xml
@@ -26,14 +26,15 @@
 	</target>
 
 	<target name="compile" depends="init">
-		<javac
-			srcdir="${src.dir}"
-			destdir="${build.dir}"
-			classpath=""
-		>
-			<compilerarg value="-Xlint"/>
-		</javac>
-	</target>
+               <javac
+                       srcdir="${src.dir}"
+                       destdir="${build.dir}"
+                       classpath=""
+                       includeantruntime="false"
+               >
+                       <compilerarg value="-Xlint"/>
+               </javac>
+       </target>
 
         <target name="buildjar">
                 <jar jarfile="${dist.dir}/${jar.file}" basedir="${build.dir}">

--- a/battle/src/battleship/BattleShip.java
+++ b/battle/src/battleship/BattleShip.java
@@ -17,10 +17,7 @@ import java.awt.event.WindowListener;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.util.Observer;
-import java.util.Observable;
-
-public class BattleShip implements Observer,WindowListener,ActionListener
+public class BattleShip implements WindowListener,ActionListener
 {
 	MenuItem miNew;
 	MenuItem miStartServer;
@@ -102,13 +99,6 @@ public class BattleShip implements Observer,WindowListener,ActionListener
 			whoseTurn = (action.equals("Local") ? Constants.LOCAL_TURN : Constants.REMOTE_TURN);
 		}
 	};
-
-/*----------------*/
-/* Observer event */
-/*----------------*/
-	public void update(Observable o, Object arg)
-	{
-	}
 
 /*-----------------*/
 /* Pseudo notifier */
@@ -432,12 +422,12 @@ public class BattleShip implements Observer,WindowListener,ActionListener
 /*-------------*/
 /* Constructor */
 /*-------------*/
-	public BattleShip()
-	{
+        @SuppressWarnings("this-escape")
+        public BattleShip()
+        {
 		runningAsServer=false;
 		connectedToServer=false;
 		changingConfig=false;
-		ini.addObserver(this);
 		build_windows();
 		whoPlays = new YesNoDialog(win, "New Game", true, "Who starts?", "Local", "Remote");
 		whoPlays.addListener(startListener);

--- a/battle/src/battleship/IniFileGen.java
+++ b/battle/src/battleship/IniFileGen.java
@@ -37,13 +37,12 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Observable;
 import java.util.Properties;
 import java.io.FileOutputStream;
 import java.io.FileInputStream;
 import java.io.File;
 
-public class IniFileGen extends Observable {
+public class IniFileGen {
         Properties props;
         String iniFileName;
         Dialog iniDialog;
@@ -76,17 +75,11 @@ public class IniFileGen extends Observable {
 /*-----------------------------------------------------*/
 /* Tell anyone who's listening that we've been updated */
 /*-----------------------------------------------------*/
-                                tellObservers();
+                                // configuration updated, no observers to notify
                         }
                         iniDialog.setVisible(false);
                 }
         };
-
-	public void tellObservers()
-	{
-		setChanged();
-		notifyObservers();
-	}
 
 /*-------------*/
 /* Constructor */
@@ -112,7 +105,7 @@ public class IniFileGen extends Observable {
 		
 		iniFileName = fileName;
 	
-		load(propDetails);
+                load(propDetails);
 
 		for(i=0;i<propDetails.length;i++)
 		{
@@ -137,8 +130,7 @@ public class IniFileGen extends Observable {
 		OK = checkAllInput();
 	}
 
-	public void load(String propDetails[][])
-	{
+        private void load(String propDetails[][]) {
 		int i;
 
 		props = new Properties();

--- a/battle/src/battleship/PlayerBoard.java
+++ b/battle/src/battleship/PlayerBoard.java
@@ -6,15 +6,16 @@ import java.awt.Graphics;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 
-public class PlayerBoard extends Canvas implements MouseListener
-{
-	private int board[][];
-	private int state;
-	private int turn;
-	private int currentShip;
-	private boolean startPlaced;
-	private int startX, startY;
-	private BattleShip parent;
+public class PlayerBoard extends Canvas implements MouseListener {
+        private static final long serialVersionUID = 1L;
+
+        private int board[][];
+        private int state;
+        private int turn;
+        private int currentShip;
+        private boolean startPlaced;
+        private int startX, startY;
+        private transient BattleShip parent;
 
 	public int getCurrentShip()
 	{
@@ -235,12 +236,14 @@ public class PlayerBoard extends Canvas implements MouseListener
 /*-------------*/
 /* Constructor */
 /*-------------*/
-	public PlayerBoard(BattleShip p)
-	{
+        @SuppressWarnings("this-escape")
+        public PlayerBoard(BattleShip p)
+        {
 		super();
 		parent = p;
 		board = new int[Constants.MAX_X][Constants.MAX_Y];
-		this.setSize(3 + (Constants.MAX_X * Constants.SQUARE_SIZE) + 3, 3 + (Constants.MAX_X * Constants.SQUARE_SIZE) + 3);
+                super.setSize(3 + (Constants.MAX_X * Constants.SQUARE_SIZE) + 3,
+                                3 + (Constants.MAX_X * Constants.SQUARE_SIZE) + 3);
 		state = 0;
 		turn = 0;
 		currentShip = 1;

--- a/battle/src/battleship/YesNoDialog.java
+++ b/battle/src/battleship/YesNoDialog.java
@@ -11,8 +11,9 @@ import java.awt.Panel;
 import java.awt.Toolkit;
 import java.awt.event.ActionListener;
 
-public class YesNoDialog extends Dialog
-{
+public class YesNoDialog extends Dialog {
+        private static final long serialVersionUID = 1L;
+
         Button btnYes,btnNo;
 	
 	public void setVisible(boolean visible)
@@ -20,20 +21,19 @@ public class YesNoDialog extends Dialog
 		super.setVisible(visible);
 	}
 
-	public YesNoDialog(Frame f, String title, boolean modal, String message)
-	{
-		super(f, title, modal);
-		buildDialog(f, title, modal, message, "Yes", "No");
-	}
+        @SuppressWarnings("this-escape")
+        public YesNoDialog(Frame f, String title, boolean modal, String message) {
+                super(f, title, modal);
+                buildDialog(f, title, modal, message, "Yes", "No");
+        }
 
-	public YesNoDialog(Frame f, String title, boolean modal, String message, String yes, String no)
-	{
-		super(f, title, modal);
-		buildDialog(f, title, modal, message, yes, no);
-	}
+        @SuppressWarnings("this-escape")
+        public YesNoDialog(Frame f, String title, boolean modal, String message, String yes, String no) {
+                super(f, title, modal);
+                buildDialog(f, title, modal, message, yes, no);
+        }
 
-        public void buildDialog(Frame f, String title, boolean modal, String message, String yes, String no)
-        {
+        private void buildDialog(Frame f, String title, boolean modal, String message, String yes, String no) {
                 String[] lines = message.split("\n");
                 int j = lines.length;
 
@@ -59,9 +59,8 @@ public class YesNoDialog extends Dialog
                 this.setLocation((s.width - d.width) / 2, (s.height - d.height) / 2);
         }
 
-	public void addListener(ActionListener a)
-	{
-		btnYes.addActionListener(a);
-		btnNo.addActionListener(a);
-	}
+        public void addListener(ActionListener a) {
+                btnYes.addActionListener(a);
+                btnNo.addActionListener(a);
+        }
 }


### PR DESCRIPTION
## Summary
- remove use of deprecated `Observer`/`Observable`
- silence "this-escape" and serialization warnings in UI classes
- make Ant build repeatable by disabling runtime classpath inclusion

## Testing
- `javac -Xlint src/battleship/*.java -d build`

------
https://chatgpt.com/codex/tasks/task_e_68b4f4310d88832196ffa7132de8f6b7