### PR TITLE
Add containerization for Maki game

### DIFF
--- a/maki/Dockerfile
+++ b/maki/Dockerfile
@@ -1,0 +1,8 @@
+# Serve the Maki game via Nginx
+FROM nginx:alpine
+
+# Copy the application into a subdirectory to preserve expected URL paths
+COPY . /usr/share/nginx/html/maki
+
+# The default nginx image already exposes port 80
+

--- a/maki/docker-compose.yaml
+++ b/maki/docker-compose.yaml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  maki:
+    build: .
+    ports:
+      - "8000:80"

--- a/maki/k8s/deployment.yaml
+++ b/maki/k8s/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: maki
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: maki
+  template:
+    metadata:
+      labels:
+        app: maki
+    spec:
+      containers:
+        - name: maki
+          image: maki:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80

--- a/maki/k8s/service.yaml
+++ b/maki/k8s/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: maki
+spec:
+  selector:
+    app: maki
+  ports:
+    - port: 80
+      targetPort: 80
+      nodePort: 30080
+  type: NodePort


### PR DESCRIPTION
## Summary
- Serve the Maki game with a lightweight Nginx Docker image
- Provide docker-compose config exposing the game on port 8000
- Add Kubernetes deployment and service manifests

## Testing
- `make -C maki clean all`


------
https://chatgpt.com/codex/tasks/task_e_68b5f91bbbd883218f21047988773190